### PR TITLE
🧹 [Code Health] Remove unsafe unwrap in MusicManager::add_to_queue

### DIFF
--- a/src/commands/music/utils/music_manager.rs
+++ b/src/commands/music/utils/music_manager.rs
@@ -532,7 +532,14 @@ impl MusicManager {
     }
 
     pub async fn add_to_queue(call: Arc<Mutex<Call>>, metadata: TrackMetadata) {
-        let input = YoutubeDl::new(HTTP_CLIENT.clone(), metadata.clone().url.unwrap());
+        let url = match metadata.url.clone() {
+            Some(u) => u,
+            None => {
+                warn!("Track metadata is missing a URL: {}", metadata.title);
+                return;
+            }
+        };
+        let input = YoutubeDl::new(HTTP_CLIENT.clone(), url);
         let mut track = Track::from(input);
         track.user_data = Arc::new(metadata);
         call.lock().await.enqueue(track).await;

--- a/src/commands/music/utils/music_manager.rs
+++ b/src/commands/music/utils/music_manager.rs
@@ -532,12 +532,9 @@ impl MusicManager {
     }
 
     pub async fn add_to_queue(call: Arc<Mutex<Call>>, metadata: TrackMetadata) {
-        let url = match metadata.url.clone() {
-            Some(u) => u,
-            None => {
-                warn!("Track metadata is missing a URL: {}", metadata.title);
-                return;
-            }
+        let Some(url) = metadata.url.clone() else {
+            warn!("Track metadata is missing a URL: {}", metadata.title);
+            return;
         };
         let input = YoutubeDl::new(HTTP_CLIENT.clone(), url);
         let mut track = Track::from(input);


### PR DESCRIPTION
🎯 **What:** Replaced an unsafe `unwrap()` call on `metadata.clone().url` in `src/commands/music/utils/music_manager.rs` with a `match` expression.
💡 **Why:** This prevents panics when attempting to play a track with missing metadata, thus improving the maintainability and reliability of the bot.
✅ **Verification:** Verified by running `cargo check` and `cargo test`, ensuring the solution compiles and no existing tests break.
✨ **Result:** The code is safer, removing a potential crashing bug without altering its primary functionality.

---
*PR created automatically by Jules for task [5736783931625291580](https://jules.google.com/task/5736783931625291580) started by @Kajoonie*