### PR TITLE
🧹 [Code Health] Remove unwrap() on GuildId in component_handlers.rs

### DIFF
--- a/src/commands/music/utils/component_handlers.rs
+++ b/src/commands/music/utils/component_handlers.rs
@@ -232,10 +232,12 @@ async fn handle_search(
         // Get the user's input from the modal.
         let input = response.inputs[0].clone();
 
+        let guild_id = interaction.guild_id.ok_or("Not in a guild")?;
+
         // Process the input as a play request.
         match MusicManager::process_play_request(
             ctx,
-            interaction.guild_id.unwrap(),
+            guild_id,
             interaction.channel_id,
             &interaction.user,
             input,


### PR DESCRIPTION
🎯 **What:** Replaced the `unwrap()` call on `interaction.guild_id` with `ok_or("Not in a guild")?` when calling `process_play_request` in `handle_search`.
💡 **Why:** Using `unwrap()` can lead to runtime panics if the `Option` is `None`. Using safe error propagation matches the pattern used elsewhere in the file and improves the maintainability and resilience of the bot.
✅ **Verification:** Verified changes through manual source code review, running the project's tests with `cargo test`, and ensuring there are no functional regressions. Removed extraneous patch files.
✨ **Result:** Improved codebase maintainability by preventing a potential source of panic.

---
*PR created automatically by Jules for task [14473685432717676566](https://jules.google.com/task/14473685432717676566) started by @Kajoonie*