### PR TITLE
🔒 Fix argument injection in yt-dlp execution

### DIFF
--- a/src/commands/music/audio_sources/related_songs/ytdl.rs
+++ b/src/commands/music/audio_sources/related_songs/ytdl.rs
@@ -38,6 +38,7 @@ impl RelatedSongsFetcher for YtDlpFetcher {
             .args([
                 "-j", // Output metadata as JSON
                 "--no-playlist",
+                "--",
                 &url,
             ])
             .output()
@@ -77,6 +78,7 @@ impl RelatedSongsFetcher for YtDlpFetcher {
                 "--no-download",
                 "--default-search",
                 "ytsearch5", // Search for 5 videos
+                "--",
                 &search_term,
             ])
             .output()

--- a/src/commands/music/audio_sources/youtube.rs
+++ b/src/commands/music/audio_sources/youtube.rs
@@ -57,6 +57,7 @@ impl AudioApi for YoutubeApi {
             .args([
                 "-j",            // Output as JSON
                 "--no-playlist", // Don't process playlists
+                "--",
                 url,
             ])
             .output()
@@ -106,6 +107,7 @@ impl YoutubeApi {
             .args([
                 "-j",            // Output as JSON
                 "--no-playlist", // Don't process playlists
+                "--",
                 &search_param,
             ])
             .output()


### PR DESCRIPTION
🎯 **What:** Fixed an argument injection vulnerability where unsanitized search terms passed to `yt-dlp` could be interpreted as command-line options.
⚠️ **Risk:** If an attacker could control the search term or URL (even indirectly), they could inject malicious command-line arguments to `yt-dlp` (e.g., `--exec`), leading to arbitrary file read, network requests, or even Remote Code Execution (RCE) on the server.
🛡️ **Solution:** Appended the POSIX-standard `--` token before the dynamic parameters (search term, URLs) in `Command::new("yt-dlp")`. This guarantees that subsequent arguments are treated solely as positional arguments and never as options.

---
*PR created automatically by Jules for task [10783388641942122551](https://jules.google.com/task/10783388641942122551) started by @Kajoonie*