### PR TITLE
⚡ Optimize queue performance by locking Mutex sequentially

### DIFF
--- a/src/commands/music/utils/event_handlers.rs
+++ b/src/commands/music/utils/event_handlers.rs
@@ -78,7 +78,8 @@ impl SongEndNotifier {
                     }
 
                     // Add the valid related song's metadata to the queue.
-                    MusicManager::add_to_queue(self.call.clone(), metadata.clone()).await;
+                    let mut call = self.call.lock().await;
+                    MusicManager::add_to_queue(&mut call, metadata.clone()).await;
                     info!(
                         "Added related song '{}' to queue for guild {}",
                         metadata.title, self.guild_id

--- a/src/commands/music/utils/music_manager.rs
+++ b/src/commands/music/utils/music_manager.rs
@@ -509,11 +509,14 @@ impl MusicManager {
         let first_track = inputs[0].clone();
 
         if let Some(handler_lock) = manager.get(guild_id) {
-            let mut handler = handler_lock.lock().await;
-            for metadata in inputs.into_iter() {
-                Self::add_to_queue(&mut handler, metadata).await;
-            }
-            Self::store_queue(guild_id, handler.queue().clone()).await;
+            let queue = {
+                let mut handler = handler_lock.lock().await;
+                for metadata in inputs.into_iter() {
+                    Self::add_to_queue(&mut handler, metadata).await;
+                }
+                handler.queue().clone()
+            };
+            Self::store_queue(guild_id, queue).await;
         }
 
         Self::start_update_task(ctx, ctx.http.clone(), guild_id, channel_id).await;

--- a/src/commands/music/utils/music_manager.rs
+++ b/src/commands/music/utils/music_manager.rs
@@ -509,10 +509,10 @@ impl MusicManager {
         let first_track = inputs[0].clone();
 
         if let Some(handler_lock) = manager.get(guild_id) {
+            let mut handler = handler_lock.lock().await;
             for metadata in inputs.into_iter() {
-                Self::add_to_queue(handler_lock.clone(), metadata).await;
+                Self::add_to_queue(&mut handler, metadata).await;
             }
-            let handler = handler_lock.lock().await;
             Self::store_queue(guild_id, handler.queue().clone()).await;
         }
 
@@ -531,7 +531,7 @@ impl MusicManager {
         embedded_messages::generic_success("Music", &reply_content)
     }
 
-    pub async fn add_to_queue(call: Arc<Mutex<Call>>, metadata: TrackMetadata) {
+    pub async fn add_to_queue(call: &mut Call, metadata: TrackMetadata) {
         let Some(url) = metadata.url.clone() else {
             warn!("Track metadata is missing a URL: {}", metadata.title);
             return;
@@ -539,7 +539,7 @@ impl MusicManager {
         let input = YoutubeDl::new(HTTP_CLIENT.clone(), url);
         let mut track = Track::from(input);
         track.user_data = Arc::new(metadata);
-        call.lock().await.enqueue(track).await;
+        call.enqueue(track).await;
     }
 
     /// If it's a URL, it iterates through `AUDIO_APIS` to find a handler.


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Changed the signature of `MusicManager::add_to_queue` to take a mutable reference to `Call` (`&mut Call`) instead of an `Arc<Mutex<Call>>`.
- In `process_play_request`, moved the lock acquisition outside the for-loop so that the lock is acquired only once for the entire batch of metadata elements instead of on each individual iteration.
- Updated the call site in `event_handlers.rs` to similarly lock beforehand and pass the mutable reference.

🎯 **Why:** The performance problem it solves
- In the original implementation, the `tokio::sync::Mutex` around `Call` was locked and awaited on every track being added to the queue in `process_play_request`. Because `add_to_queue` locks and unlocks the mutex repeatedly, this resulted in yielding back to the tokio scheduler for every track inserted, causing unnecessary context-switching overhead.
- Locking it once prior to iterating through the tracks drastically reduces lock contention and context-switching overhead, ensuring that adding large playlists operates smoothly and efficiently without continuous task suspension.

📊 **Measured Improvement:**
- Because the performance issue is deeply tied to `tokio::sync::Mutex` lock yielding over multiple operations within a Serenity voice session queue, a standalone benchmark mock replicating this exact discord/songbird environment would be complex. However, the performance benefit is a classic async rust optimization: reducing consecutive `.lock().await` calls down to a single lock before the batch operation guarantees atomic insertion into the queue while strictly eliminating `n-1` scheduler yields (where `n` is the number of queued items). This significantly prevents task queue jitter in high-load scenarios.

---
*PR created automatically by Jules for task [2065461285235559771](https://jules.google.com/task/2065461285235559771) started by @Kajoonie*